### PR TITLE
Ad astra

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Thermoo Patches is still a WIP. The following patches are currently planned:
 - [x] Colorful Hearts: Temperature now properly displays on HUD.
 - [x] Overflowing Bars: Temperature now properly displays on HUD.
 - [x] Fabric Seasons: Makes Frostiful/Scorchful aware of current season.
-- [ ] Serene Seasons: Makes Frostiful/Scorchful aware of current season.
+- [ ] Serene Seasons: Makes Frostiful/Scorchful aware of current season (coming to 1.20.4+ only).
 - [x] Immersive Weathering: Eating Icicles and Ice Sickles cools the player.
 - [ ] Spell Engine
 - [ ] Ad Astra

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Thermoo Patches is still a WIP. The following patches are currently planned:
 - [ ] Serene Seasons: Makes Frostiful/Scorchful aware of current season (coming to 1.20.4+ only).
 - [x] Immersive Weathering: Eating Icicles and Ice Sickles cools the player.
 - [ ] Spell Engine
-- [ ] Ad Astra
+- [x] Ad Astra: Adds more extreme temperatures on various planets, and disables the normal temperature effects
 - [x] Origins: Blazeborn is immune to heat and vulnerable to cold.
 - [x] Mob Origins: Snow Golem is immune to cold and vulnerable to heat. Snow Golem temperature system also removed (redundant with Thermoo).
 - [x] Extra Origins: Piglin origin has extra heat resistance

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ repositories {
             includeGroup "maven.modrinth"
         }
     }
+    maven { url "https://maven.teamresourceful.com/repository/maven-public/" }
 }
 
 loom {
@@ -73,6 +74,7 @@ dependencies {
     modCompileOnly "maven.modrinth:overflowing-bars:${project.overflowingbars_version}"
     modCompileOnly "maven.modrinth:immersive-weathering:${project.immersive_weathering_version}"
     modCompileOnly "maven.modrinth:fabric-seasons:${project.fabric_seasons_version}"
+    modCompileOnly group: "earth.terrarium.adastra", name: "ad_astra-fabric-${project.minecraft_version}", version: "${project.ad_astra_version}"
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,9 @@ dependencies {
     modCompileOnly "maven.modrinth:overflowing-bars:${project.overflowingbars_version}"
     modCompileOnly "maven.modrinth:immersive-weathering:${project.immersive_weathering_version}"
     modCompileOnly "maven.modrinth:fabric-seasons:${project.fabric_seasons_version}"
-    modCompileOnly group: "earth.terrarium.adastra", name: "ad_astra-fabric-${project.minecraft_version}", version: "${project.ad_astra_version}"
+    modCompileOnly ("earth.terrarium.adastra:ad_astra-fabric-${project.minecraft_version}:${project.ad_astra_version}") {
+        transitive = false
+    }
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,3 +26,4 @@ immersive_weathering_version=1.20.1-2.0.1
 fabric_seasons_version=2.3+1.20
 colorfulhearts_version=4.0.4
 overflowingbars_version=v8.0.0-1.20.1-Fabric
+ad_astra_version=1.15.18

--- a/mappings/yarn-custom.tiny
+++ b/mappings/yarn-custom.tiny
@@ -1,3 +1,7 @@
 tiny	2	0	intermediary	named
 c	net/minecraft/class_329	net/minecraft/client/gui/hud/InGameHud
 	m	(Lnet/minecraft/class_332;)V	method_1741	rrenderMountHealth
+c	net/minecraft/class_3829	net/minecraft/util/Clearable
+	m	()V	method_5448	cclear
+c	net/minecraft/class_437	net/minecraft/client/gui/screen/Screen
+	m	()V	method_25419	cclose

--- a/src/main/java/com/github/thedeathlycow/thermoo/patches/IntegratedMod.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/patches/IntegratedMod.java
@@ -7,6 +7,7 @@ public enum IntegratedMod {
     LIBHUD("libhud", "https://modrinth.com/mod/libhud"),
     ARMOR_POINTS_PP("armorpointspp", "https://modrinth.com/mod/armorpoints"),
     COLORFUL_HEARTS("colorfulhearts", "https://modrinth.com/mod/colorful-hearts"),
+    OVERFLOWING_BARS("overflowingbars", "https://modrinth.com/mod/overflowing-bars"),
     IMMERSIVE_WEATHERING("immersive_weathering", "https://modrinth.com/mod/immersive-weathering"),
     FABRIC_SEASONS("seasons", "https://modrinth.com/mod/fabric-seasons"),
     ORIGINS("origins", "https://modrinth.com/mod/origins"),

--- a/src/main/java/com/github/thedeathlycow/thermoo/patches/IntegratedMod.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/patches/IntegratedMod.java
@@ -11,7 +11,8 @@ public enum IntegratedMod {
     FABRIC_SEASONS("seasons", "https://modrinth.com/mod/fabric-seasons"),
     ORIGINS("origins", "https://modrinth.com/mod/origins"),
     MOB_ORIGINS("moborigins", "https://modrinth.com/mod/moborigins"),
-    EXTRA_ORIGINS("extraorigins", "https://modrinth.com/mod/extra-origins");
+    EXTRA_ORIGINS("extraorigins", "https://modrinth.com/mod/extra-origins"),
+    AD_ASTRA("ad_astra", "https://modrinth.com/mod/ad-astra");
 
     private final String id;
 

--- a/src/main/java/com/github/thedeathlycow/thermoo/patches/ThermooPatches.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/patches/ThermooPatches.java
@@ -1,5 +1,6 @@
 package com.github.thedeathlycow.thermoo.patches;
 
+import com.github.thedeathlycow.thermoo.patches.adastra.AdAstraIntegration;
 import com.github.thedeathlycow.thermoo.patches.config.ThermooPatchesConfig;
 import com.github.thedeathlycow.thermoo.patches.fabricseasons.FabricSeasonsProvider;
 import me.shedaniel.autoconfig.AutoConfig;
@@ -30,6 +31,9 @@ public class ThermooPatches implements ModInitializer {
         AutoConfig.register(ThermooPatchesConfig.class, GsonConfigSerializer::new);
         checkMultiDependency(IntegratedMod.ARMOR_POINTS_PP, IntegratedMod.LIBHUD);
         FabricSeasonsProvider.registerSeasonProviderEvent();
+        if (IntegratedMod.AD_ASTRA.isModLoaded()) {
+            AdAstraIntegration.init();
+        }
         logPatchedMods();
     }
 

--- a/src/main/java/com/github/thedeathlycow/thermoo/patches/adastra/AdAstraIntegration.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/patches/adastra/AdAstraIntegration.java
@@ -1,0 +1,24 @@
+package com.github.thedeathlycow.thermoo.patches.adastra;
+
+import com.github.thedeathlycow.thermoo.api.temperature.event.EnvironmentControllerInitializeEvent;
+import earth.terrarium.adastra.api.events.AdAstraEvents;
+
+public class AdAstraIntegration {
+
+
+
+    public static void init() {
+        // prevent ad astra temperature ticks - to be replaced by Thermoo env controller
+        AdAstraEvents.TemperatureTickEvent.register((serverLevel, livingEntity) -> false);
+
+        EnvironmentControllerInitializeEvent.EVENT.register(
+                EnvironmentControllerInitializeEvent.OVERRIDE_PHASE,
+                SpaceEnvironmentController::new
+        );
+    }
+
+    private AdAstraIntegration() {
+
+    }
+
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/patches/adastra/AdAstraIntegration.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/patches/adastra/AdAstraIntegration.java
@@ -9,7 +9,6 @@ import com.github.thedeathlycow.thermoo.patches.config.AdAstraConfig;
 import earth.terrarium.adastra.api.events.AdAstraEvents;
 import earth.terrarium.adastra.api.planets.Planet;
 import earth.terrarium.adastra.api.planets.PlanetApi;
-import earth.terrarium.adastra.api.systems.PlanetData;
 import earth.terrarium.adastra.api.systems.TemperatureApi;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;

--- a/src/main/java/com/github/thedeathlycow/thermoo/patches/adastra/AdAstraIntegration.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/patches/adastra/AdAstraIntegration.java
@@ -1,20 +1,65 @@
 package com.github.thedeathlycow.thermoo.patches.adastra;
 
+import com.github.thedeathlycow.thermoo.api.temperature.HeatingModes;
 import com.github.thedeathlycow.thermoo.api.temperature.event.EnvironmentControllerInitializeEvent;
+import com.github.thedeathlycow.thermoo.patches.ThermooPatches;
+import com.github.thedeathlycow.thermoo.patches.config.AdAstraConfig;
 import earth.terrarium.adastra.api.events.AdAstraEvents;
+import earth.terrarium.adastra.api.planets.Planet;
+import earth.terrarium.adastra.api.planets.PlanetApi;
+import earth.terrarium.adastra.api.systems.TemperatureApi;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 
 public class AdAstraIntegration {
 
-
-
     public static void init() {
-        // prevent ad astra temperature ticks - to be replaced by Thermoo env controller
-        AdAstraEvents.TemperatureTickEvent.register((serverLevel, livingEntity) -> false);
+        // prevent ad astra temperature ticks for players - to be replaced by Thermoo env controller
+        AdAstraEvents.HotTemperatureTickEvent.register(
+                (serverWorld, livingEntity) -> {
+                    int temperatureChange = getPlanetTemperature(
+                            serverWorld, livingEntity.getBlockPos()
+                    );
+                    livingEntity.thermoo$addTemperature(temperatureChange, HeatingModes.PASSIVE);
+
+                    return false;
+                }
+        );
+        AdAstraEvents.ColdTemperatureTickEvent.register(
+                (serverWorld, livingEntity) -> {
+                    int temperatureChange = getPlanetTemperature(
+                            serverWorld, livingEntity.getBlockPos()
+                    );
+                    livingEntity.thermoo$addTemperature(temperatureChange, HeatingModes.PASSIVE);
+
+                    return false;
+                }
+        );
 
         EnvironmentControllerInitializeEvent.EVENT.register(
                 EnvironmentControllerInitializeEvent.OVERRIDE_PHASE,
                 SpaceEnvironmentController::new
         );
+    }
+
+    static int getPlanetTemperature(World world, BlockPos pos) {
+        Planet planet = PlanetApi.API.getPlanet(world);
+        if (planet == null) {
+            return 0;
+        }
+
+        AdAstraConfig config = ThermooPatches.getConfig().adAstraConfig;
+
+        int temperature = 0;
+        if (planet.isSpace()) {
+            temperature = config.getOrbitTemperaturePerSecond();
+        } else if (TemperatureApi.API.isHot(world, pos)) {
+            temperature = config.getHotPlanetTemperaturePerSecond();
+        } else if (TemperatureApi.API.isCold(world, pos)) {
+            temperature = config.getColdPlanetTemperaturePerSecond();
+        }
+
+        return temperature;
     }
 
     private AdAstraIntegration() {

--- a/src/main/java/com/github/thedeathlycow/thermoo/patches/adastra/SpaceEnvironmentController.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/patches/adastra/SpaceEnvironmentController.java
@@ -2,8 +2,10 @@ package com.github.thedeathlycow.thermoo.patches.adastra;
 
 import com.github.thedeathlycow.thermoo.api.temperature.EnvironmentController;
 import com.github.thedeathlycow.thermoo.api.temperature.EnvironmentControllerDecorator;
-import earth.terrarium.adastra.api.planets.Planet;
+import com.github.thedeathlycow.thermoo.patches.ThermooPatches;
+import com.github.thedeathlycow.thermoo.patches.config.AdAstraConfig;
 import earth.terrarium.adastra.api.planets.PlanetApi;
+import earth.terrarium.adastra.api.systems.TemperatureApi;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -20,18 +22,22 @@ public class SpaceEnvironmentController extends EnvironmentControllerDecorator {
 
     @Override
     public int getLocalTemperatureChange(World world, BlockPos pos) {
-        Planet planet = PlanetApi.API.getPlanet(world.getRegistryKey());
-//
-//        if (planet == null) {
-//            return super.getLocalTemperatureChange(world, pos);
-//        } else {
-//
-//        }
-        return 0;
+        if (PlanetApi.API.isPlanet(world)) {
+            // we still calculate this because it may not necessarily apply to a player
+            return AdAstraIntegration.getPlanetTemperature(world, pos);
+        } else {
+            return super.getLocalTemperatureChange(world, pos);
+        }
     }
 
     @Override
     public int getEnvironmentTemperatureForPlayer(PlayerEntity player, int localTemperature) {
+        World world = player.getWorld();
+        if (PlanetApi.API.isPlanet(world)) {
+            // cancel for thermoo, use ad astra api
+            return 0;
+        }
+
         return super.getEnvironmentTemperatureForPlayer(player, localTemperature);
     }
 }

--- a/src/main/java/com/github/thedeathlycow/thermoo/patches/adastra/SpaceEnvironmentController.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/patches/adastra/SpaceEnvironmentController.java
@@ -1,0 +1,37 @@
+package com.github.thedeathlycow.thermoo.patches.adastra;
+
+import com.github.thedeathlycow.thermoo.api.temperature.EnvironmentController;
+import com.github.thedeathlycow.thermoo.api.temperature.EnvironmentControllerDecorator;
+import earth.terrarium.adastra.api.planets.Planet;
+import earth.terrarium.adastra.api.planets.PlanetApi;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public class SpaceEnvironmentController extends EnvironmentControllerDecorator {
+    /**
+     * Constructs a decorator out of a base controller
+     *
+     * @param controller The base {@link #controller}
+     */
+    public SpaceEnvironmentController(EnvironmentController controller) {
+        super(controller);
+    }
+
+    @Override
+    public int getLocalTemperatureChange(World world, BlockPos pos) {
+        Planet planet = PlanetApi.API.getPlanet(world.getRegistryKey());
+//
+//        if (planet == null) {
+//            return super.getLocalTemperatureChange(world, pos);
+//        } else {
+//
+//        }
+        return 0;
+    }
+
+    @Override
+    public int getEnvironmentTemperatureForPlayer(PlayerEntity player, int localTemperature) {
+        return super.getEnvironmentTemperatureForPlayer(player, localTemperature);
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/patches/adastra/SpaceEnvironmentController.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/patches/adastra/SpaceEnvironmentController.java
@@ -2,10 +2,8 @@ package com.github.thedeathlycow.thermoo.patches.adastra;
 
 import com.github.thedeathlycow.thermoo.api.temperature.EnvironmentController;
 import com.github.thedeathlycow.thermoo.api.temperature.EnvironmentControllerDecorator;
-import com.github.thedeathlycow.thermoo.patches.ThermooPatches;
-import com.github.thedeathlycow.thermoo.patches.config.AdAstraConfig;
+import earth.terrarium.adastra.api.planets.Planet;
 import earth.terrarium.adastra.api.planets.PlanetApi;
-import earth.terrarium.adastra.api.systems.TemperatureApi;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -22,8 +20,10 @@ public class SpaceEnvironmentController extends EnvironmentControllerDecorator {
 
     @Override
     public int getLocalTemperatureChange(World world, BlockPos pos) {
-        if (PlanetApi.API.isPlanet(world)) {
+        Planet planet = PlanetApi.API.getPlanet(world);
+        if (planet != null && !planet.oxygen()) {
             // we still calculate this because it may not necessarily apply to a player
+            // eg, may want to have it for the scorchful thermometer
             return AdAstraIntegration.getPlanetTemperature(world, pos);
         } else {
             return super.getLocalTemperatureChange(world, pos);
@@ -33,7 +33,8 @@ public class SpaceEnvironmentController extends EnvironmentControllerDecorator {
     @Override
     public int getEnvironmentTemperatureForPlayer(PlayerEntity player, int localTemperature) {
         World world = player.getWorld();
-        if (PlanetApi.API.isPlanet(world)) {
+        Planet planet = PlanetApi.API.getPlanet(world);
+        if (planet != null && !planet.oxygen()) {
             // cancel for thermoo, use ad astra api
             return 0;
         }

--- a/src/main/java/com/github/thedeathlycow/thermoo/patches/config/AdAstraConfig.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/patches/config/AdAstraConfig.java
@@ -1,0 +1,28 @@
+package com.github.thedeathlycow.thermoo.patches.config;
+
+import com.github.thedeathlycow.thermoo.api.util.TemperatureConverter;
+import com.github.thedeathlycow.thermoo.patches.ThermooPatches;
+import me.shedaniel.autoconfig.ConfigData;
+import me.shedaniel.autoconfig.annotation.Config;
+
+@Config(name = ThermooPatches.MODID + ".ad_astra_config")
+public class AdAstraConfig implements ConfigData {
+
+    int hotPlanetTemperaturePerSecond = TemperatureConverter.celsiusToTemperatureTick(70.0) * 20;
+
+    int coldPlanetTemperaturePerSecond = TemperatureConverter.celsiusToTemperatureTick(-50.0) * 20;
+
+    int orbitTemperaturePerSecond = TemperatureConverter.celsiusToTemperatureTick(-50.0) * 20;
+
+    public int getHotPlanetTemperaturePerSecond() {
+        return hotPlanetTemperaturePerSecond;
+    }
+
+    public int getColdPlanetTemperaturePerSecond() {
+        return coldPlanetTemperaturePerSecond;
+    }
+
+    public int getOrbitTemperaturePerSecond() {
+        return orbitTemperaturePerSecond;
+    }
+}

--- a/src/main/java/com/github/thedeathlycow/thermoo/patches/config/AdAstraConfig.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/patches/config/AdAstraConfig.java
@@ -1,6 +1,5 @@
 package com.github.thedeathlycow.thermoo.patches.config;
 
-import com.github.thedeathlycow.thermoo.api.util.TemperatureConverter;
 import com.github.thedeathlycow.thermoo.patches.ThermooPatches;
 import me.shedaniel.autoconfig.ConfigData;
 import me.shedaniel.autoconfig.annotation.Config;
@@ -8,21 +7,9 @@ import me.shedaniel.autoconfig.annotation.Config;
 @Config(name = ThermooPatches.MODID + ".ad_astra_config")
 public class AdAstraConfig implements ConfigData {
 
-    int hotPlanetTemperaturePerSecond = TemperatureConverter.celsiusToTemperatureTick(70.0) * 20;
+    boolean enableSpacePassiveTemperature = true;
 
-    int coldPlanetTemperaturePerSecond = TemperatureConverter.celsiusToTemperatureTick(-50.0) * 20;
-
-    int orbitTemperaturePerSecond = TemperatureConverter.celsiusToTemperatureTick(-50.0) * 20;
-
-    public int getHotPlanetTemperaturePerSecond() {
-        return hotPlanetTemperaturePerSecond;
-    }
-
-    public int getColdPlanetTemperaturePerSecond() {
-        return coldPlanetTemperaturePerSecond;
-    }
-
-    public int getOrbitTemperaturePerSecond() {
-        return orbitTemperaturePerSecond;
+    public boolean enableSpacePassiveTemperature() {
+        return enableSpacePassiveTemperature;
     }
 }

--- a/src/main/java/com/github/thedeathlycow/thermoo/patches/config/ThermooPatchesConfig.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/patches/config/ThermooPatchesConfig.java
@@ -17,4 +17,8 @@ public class ThermooPatchesConfig extends PartitioningSerializer.GlobalData {
     @ConfigEntry.Gui.Tooltip
     public ImmersiveWeatheringConfig immersiveWeatheringConfig = new ImmersiveWeatheringConfig();
 
+    @ConfigEntry.Gui.CollapsibleObject
+    @ConfigEntry.Gui.Tooltip
+    public AdAstraConfig adAstraConfig = new AdAstraConfig();
+
 }

--- a/src/main/java/com/github/thedeathlycow/thermoo/patches/fabricseasons/FabricSeasonsProvider.java
+++ b/src/main/java/com/github/thedeathlycow/thermoo/patches/fabricseasons/FabricSeasonsProvider.java
@@ -3,7 +3,6 @@ package com.github.thedeathlycow.thermoo.patches.fabricseasons;
 import com.github.thedeathlycow.thermoo.api.season.ThermooSeasonEvents;
 import com.github.thedeathlycow.thermoo.api.season.ThermooSeasons;
 import com.github.thedeathlycow.thermoo.patches.IntegratedMod;
-import com.github.thedeathlycow.thermoo.patches.ThermooPatches;
 import io.github.lucaargolo.seasons.FabricSeasons;
 import io.github.lucaargolo.seasons.utils.Season;
 

--- a/src/main/resources/assets/thermoo-patches/lang/en_us.json
+++ b/src/main/resources/assets/thermoo-patches/lang/en_us.json
@@ -23,5 +23,9 @@
     "text.autoconfig.thermoo-patches.option.immersiveWeatheringConfig": "Immersive Weathering Config",
     "text.autoconfig.thermoo-patches.option.immersiveWeatheringConfig.@Tooltip": "Requires Immersive Weathering",
     "text.autoconfig.thermoo-patches.option.immersiveWeatheringConfig.freezingFromIcicleFall": "Freezing from falling on icicle",
-    "text.autoconfig.thermoo-patches.option.immersiveWeatheringConfig.freezingFromEatingIcicle": "Freezing from eating icicles and Ice Sickles"
+    "text.autoconfig.thermoo-patches.option.immersiveWeatheringConfig.freezingFromEatingIcicle": "Freezing from eating icicles and Ice Sickles",
+    
+    "text.autoconfig.thermoo-patches.option.adAstraConfig": "Ad Astra Config",
+    "text.autoconfig.thermoo-patches.option.adAstraConfig.@Tooltip": "Requires Ad Astra",
+    "text.autoconfig.thermoo-patches.option.adAstraConfig.enableSpacePassiveTemperature": "Enable passive temperature in Outer Space"
 }


### PR DESCRIPTION
Adds support for the Ad Astra mod. All new planets except Glacio now provide passive temperature ticks rather than their normal fire/freezing effects. Glacio has oxygen, and so still works like the Overworld. 

Earth is unaffected.